### PR TITLE
Implement ResNet34 multi-task STR model + training loop + dataloader label fix

### DIFF
--- a/jersey_number_dataset.py
+++ b/jersey_number_dataset.py
@@ -64,8 +64,10 @@ data_transforms = {
 }
 
 class JerseyNumberDataset(Dataset):
-    def __init__(self, annotations_file, img_dir, mode='train'):
-        self.transform = data_transforms[mode]
+    def __init__(self, annotations_file, img_dir, mode='train', arch='resnet34'):
+        if 'resnet' in arch:
+            arch = 'resnet'
+        self.transform = data_transforms[mode][arch]
         self.img_labels = pd.read_csv(annotations_file)
         unqiue_ids = np.unique(self.img_labels.iloc[:, 1].to_numpy())
         print(f"Datafile:{annotations_file}, number of labels:{len(self.img_labels)}, unique ids: {len(unqiue_ids)}")
@@ -83,8 +85,10 @@ class JerseyNumberDataset(Dataset):
         return image, label
 
 class JerseyNumberMultitaskDataset(Dataset):
-    def __init__(self, annotations_file, img_dir, mode='train'):
-        self.transform = data_transforms[mode]
+    def __init__(self, annotations_file, img_dir, mode='train', arch='resnet34'):
+        if 'resnet' in arch:
+            arch = 'resnet'
+        self.transform = data_transforms[mode][arch]
         self.img_labels = pd.read_csv(annotations_file)
         unqiue_ids = np.unique(self.img_labels.iloc[:, 1].to_numpy())
         print(f"Datafile:{annotations_file}, number of labels:{len(self.img_labels)}, unique ids: {len(unqiue_ids)}")
@@ -94,21 +98,25 @@ class JerseyNumberMultitaskDataset(Dataset):
         return len(self.img_labels)
 
     def get_digit_labels(self, label):
+        label = int(label)
+        if not (0 <= label <= 99):
+            raise ValueError(f"Expected jersey label in [0, 99], got {label}")
+
         if label < 10:
-            return label, 10
-        else:
-            return label // 10, label % 10
+            # Single-digit jersey: tens uses blank class index 10.
+            return 10, label
+
+        return label // 10, label % 10
 
     def __getitem__(self, idx):
         img_path = os.path.join(self.img_dir, self.img_labels.iloc[idx, 0])
         image = Image.open(img_path).convert('RGB')
-        label = self.img_labels.iloc[idx, 1]
-        digit1, digit2 = self.get_digit_labels(label)
-        if not (label> 0 and label < 100 and digit1 < 10 and digit1 > 0 and digit2 > -1 and digit2 < 11):
-            print(label, digit1, digit2)
+        label_full = int(self.img_labels.iloc[idx, 1])
+        label_tens, label_ones = self.get_digit_labels(label_full)
+
         if self.transform:
             image = self.transform(image)
-        return image, label, digit1, digit2
+        return image, label_full, label_tens, label_ones
 
 class UnlabelledJerseyNumberLegibilityDataset(Dataset):
     def __init__(self, image_paths, mode='test', arch='resnet18'):

--- a/recognition.py
+++ b/recognition.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import torch
+from torch import nn
+from torchvision import models
+
+
+def _build_resnet34(pretrained: bool = True) -> nn.Module:
+    """Build a ResNet34 while remaining compatible across torchvision versions."""
+    try:
+        weights = models.ResNet34_Weights.DEFAULT if pretrained else None
+        return models.resnet34(weights=weights)
+    except (AttributeError, TypeError):
+        return models.resnet34(pretrained=pretrained)
+
+
+class MultiTaskSTRRecognizer(nn.Module):
+    """
+    Shared-backbone multi-task STR model for jersey number recognition.
+
+    Outputs:
+    - full head: 100 classes (0-99)
+    - tens head: 11 classes (0-9 + blank at index 10)
+    - ones head: 10 classes (0-9)
+    """
+
+    def __init__(self, pretrained: bool = True, freeze_backbone: bool = False) -> None:
+        super().__init__()
+
+        backbone = _build_resnet34(pretrained=pretrained)
+        feature_dim = backbone.fc.in_features
+        backbone.fc = nn.Identity()
+        self.backbone = backbone
+
+        if freeze_backbone:
+            for param in self.backbone.parameters():
+                param.requires_grad = False
+
+        self.head_full = nn.Linear(feature_dim, 100)
+        self.head_tens = nn.Linear(feature_dim, 11)
+        self.head_ones = nn.Linear(feature_dim, 10)
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        features = self.backbone(x)
+        out_full = self.head_full(features)
+        out_tens = self.head_tens(features)
+        out_ones = self.head_ones(features)
+        return out_full, out_tens, out_ones
+

--- a/train_multitask.py
+++ b/train_multitask.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Dict, Tuple
+
+import torch
+from torch import nn
+from torch.optim import Adam
+from torch.utils.data import DataLoader, Dataset
+from torchvision import datasets, transforms
+from tqdm import tqdm
+
+from recognition import MultiTaskSTRRecognizer
+
+
+class MultiTaskImageFolderDataset(Dataset):
+    """
+    Wrap torchvision ImageFolder and emit:
+    (image, label_full, label_tens, label_ones)
+    """
+
+    def __init__(self, root: str, image_transform: transforms.Compose) -> None:
+        self.base_dataset = datasets.ImageFolder(root=root, transform=image_transform)
+        self.idx_to_full_label = self._build_label_map(self.base_dataset.class_to_idx)
+
+    @staticmethod
+    def _build_label_map(class_to_idx: Dict[str, int]) -> Dict[int, int]:
+        idx_to_full_label: Dict[int, int] = {}
+        for class_name, class_idx in class_to_idx.items():
+            try:
+                full_label = int(class_name)
+            except ValueError as exc:
+                raise ValueError(
+                    f"Class folder '{class_name}' is not numeric. Expected folder names 0..99."
+                ) from exc
+
+            if not (0 <= full_label <= 99):
+                raise ValueError(
+                    f"Invalid class folder '{class_name}'. Expected jersey labels in [0, 99]."
+                )
+            idx_to_full_label[class_idx] = full_label
+        return idx_to_full_label
+
+    @staticmethod
+    def split_digits(full_label: int) -> Tuple[int, int]:
+        if full_label < 10:
+            return 10, full_label
+        return full_label // 10, full_label % 10
+
+    def __len__(self) -> int:
+        return len(self.base_dataset)
+
+    def __getitem__(self, index: int):
+        image, class_idx = self.base_dataset[index]
+        label_full = self.idx_to_full_label[class_idx]
+        label_tens, label_ones = self.split_digits(label_full)
+        return image, label_full, label_tens, label_ones
+
+
+def train_one_epoch(
+    model: nn.Module,
+    dataloader: DataLoader,
+    criterion: nn.Module,
+    optimizer: torch.optim.Optimizer,
+    device: torch.device,
+    epoch: int,
+    num_epochs: int,
+) -> Dict[str, float]:
+    model.train()
+    running = {
+        "total_loss": 0.0,
+        "loss_full": 0.0,
+        "loss_tens": 0.0,
+        "loss_ones": 0.0,
+        "correct_full": 0,
+        "num_samples": 0,
+    }
+
+    progress = tqdm(dataloader, desc=f"Epoch {epoch}/{num_epochs} [train]")
+    for images, labels_full, labels_tens, labels_ones in progress:
+        images = images.to(device, non_blocking=True)
+        labels_full = labels_full.to(device, dtype=torch.long, non_blocking=True)
+        labels_tens = labels_tens.to(device, dtype=torch.long, non_blocking=True)
+        labels_ones = labels_ones.to(device, dtype=torch.long, non_blocking=True)
+
+        optimizer.zero_grad(set_to_none=True)
+
+        out_full, out_tens, out_ones = model(images)
+        loss_full = criterion(out_full, labels_full)
+        loss_tens = criterion(out_tens, labels_tens)
+        loss_ones = criterion(out_ones, labels_ones)
+        total_loss = loss_full + loss_tens + loss_ones
+
+        total_loss.backward()
+        optimizer.step()
+
+        batch_size = images.size(0)
+        running["num_samples"] += batch_size
+        running["total_loss"] += total_loss.item() * batch_size
+        running["loss_full"] += loss_full.item() * batch_size
+        running["loss_tens"] += loss_tens.item() * batch_size
+        running["loss_ones"] += loss_ones.item() * batch_size
+
+        preds_full = out_full.argmax(dim=1)
+        running["correct_full"] += (preds_full == labels_full).sum().item()
+
+        avg_total = running["total_loss"] / running["num_samples"]
+        avg_full = running["loss_full"] / running["num_samples"]
+        avg_tens = running["loss_tens"] / running["num_samples"]
+        avg_ones = running["loss_ones"] / running["num_samples"]
+        avg_acc = running["correct_full"] / running["num_samples"]
+        progress.set_postfix(
+            total=f"{avg_total:.4f}",
+            full=f"{avg_full:.4f}",
+            tens=f"{avg_tens:.4f}",
+            ones=f"{avg_ones:.4f}",
+            acc_full=f"{avg_acc:.4f}",
+        )
+
+    num_samples = running["num_samples"]
+    return {
+        "total_loss": running["total_loss"] / num_samples,
+        "loss_full": running["loss_full"] / num_samples,
+        "loss_tens": running["loss_tens"] / num_samples,
+        "loss_ones": running["loss_ones"] / num_samples,
+        "acc_full": running["correct_full"] / num_samples,
+    }
+
+
+@torch.no_grad()
+def validate_one_epoch(
+    model: nn.Module,
+    dataloader: DataLoader,
+    criterion: nn.Module,
+    device: torch.device,
+    epoch: int,
+    num_epochs: int,
+) -> Dict[str, float]:
+    model.eval()
+    running = {
+        "total_loss": 0.0,
+        "loss_full": 0.0,
+        "loss_tens": 0.0,
+        "loss_ones": 0.0,
+        "correct_full": 0,
+        "num_samples": 0,
+    }
+
+    progress = tqdm(dataloader, desc=f"Epoch {epoch}/{num_epochs} [val]")
+    for images, labels_full, labels_tens, labels_ones in progress:
+        images = images.to(device, non_blocking=True)
+        labels_full = labels_full.to(device, dtype=torch.long, non_blocking=True)
+        labels_tens = labels_tens.to(device, dtype=torch.long, non_blocking=True)
+        labels_ones = labels_ones.to(device, dtype=torch.long, non_blocking=True)
+
+        out_full, out_tens, out_ones = model(images)
+        loss_full = criterion(out_full, labels_full)
+        loss_tens = criterion(out_tens, labels_tens)
+        loss_ones = criterion(out_ones, labels_ones)
+        total_loss = loss_full + loss_tens + loss_ones
+
+        batch_size = images.size(0)
+        running["num_samples"] += batch_size
+        running["total_loss"] += total_loss.item() * batch_size
+        running["loss_full"] += loss_full.item() * batch_size
+        running["loss_tens"] += loss_tens.item() * batch_size
+        running["loss_ones"] += loss_ones.item() * batch_size
+
+        preds_full = out_full.argmax(dim=1)
+        running["correct_full"] += (preds_full == labels_full).sum().item()
+
+        avg_total = running["total_loss"] / running["num_samples"]
+        avg_full = running["loss_full"] / running["num_samples"]
+        avg_tens = running["loss_tens"] / running["num_samples"]
+        avg_ones = running["loss_ones"] / running["num_samples"]
+        avg_acc = running["correct_full"] / running["num_samples"]
+        progress.set_postfix(
+            total=f"{avg_total:.4f}",
+            full=f"{avg_full:.4f}",
+            tens=f"{avg_tens:.4f}",
+            ones=f"{avg_ones:.4f}",
+            acc_full=f"{avg_acc:.4f}",
+        )
+
+    num_samples = running["num_samples"]
+    return {
+        "total_loss": running["total_loss"] / num_samples,
+        "loss_full": running["loss_full"] / num_samples,
+        "loss_tens": running["loss_tens"] / num_samples,
+        "loss_ones": running["loss_ones"] / num_samples,
+        "acc_full": running["correct_full"] / num_samples,
+    }
+
+
+def build_dataloader(
+    data_root: str, batch_size: int, num_workers: int, shuffle: bool
+) -> DataLoader:
+    image_transform = transforms.Compose(
+        [
+            transforms.Resize((256, 256)),
+            transforms.ToTensor(),
+            transforms.Normalize(
+                mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+            ),
+        ]
+    )
+    dataset = MultiTaskImageFolderDataset(root=data_root, image_transform=image_transform)
+    return DataLoader(
+        dataset,
+        batch_size=batch_size,
+        shuffle=shuffle,
+        num_workers=num_workers,
+        pin_memory=torch.cuda.is_available(),
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--train-root", type=str, required=True)
+    parser.add_argument("--val-root", type=str, default=None)
+    parser.add_argument("--epochs", type=int, default=30)
+    parser.add_argument("--batch-size", type=int, default=32)
+    parser.add_argument("--num-workers", type=int, default=4)
+    parser.add_argument("--checkpoint-dir", type=str, default="checkpoints")
+    parser.add_argument("--no-pretrained", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    train_loader = build_dataloader(
+        data_root=args.train_root,
+        batch_size=args.batch_size,
+        num_workers=args.num_workers,
+        shuffle=True,
+    )
+
+    val_loader = None
+    if args.val_root:
+        val_loader = build_dataloader(
+            data_root=args.val_root,
+            batch_size=args.batch_size,
+            num_workers=args.num_workers,
+            shuffle=False,
+        )
+
+    model = MultiTaskSTRRecognizer(pretrained=not args.no_pretrained).to(device)
+    criterion = nn.CrossEntropyLoss()
+    optimizer = Adam(model.parameters(), lr=1e-4)
+
+    checkpoint_dir = Path(args.checkpoint_dir)
+    checkpoint_dir.mkdir(parents=True, exist_ok=True)
+
+    for epoch in range(1, args.epochs + 1):
+        train_metrics = train_one_epoch(
+            model=model,
+            dataloader=train_loader,
+            criterion=criterion,
+            optimizer=optimizer,
+            device=device,
+            epoch=epoch,
+            num_epochs=args.epochs,
+        )
+
+        print(
+            f"[train] epoch={epoch} "
+            f"total={train_metrics['total_loss']:.4f} "
+            f"full={train_metrics['loss_full']:.4f} "
+            f"tens={train_metrics['loss_tens']:.4f} "
+            f"ones={train_metrics['loss_ones']:.4f} "
+            f"acc_full={train_metrics['acc_full']:.4f}"
+        )
+
+        if val_loader is not None:
+            val_metrics = validate_one_epoch(
+                model=model,
+                dataloader=val_loader,
+                criterion=criterion,
+                device=device,
+                epoch=epoch,
+                num_epochs=args.epochs,
+            )
+            print(
+                f"[val]   epoch={epoch} "
+                f"total={val_metrics['total_loss']:.4f} "
+                f"full={val_metrics['loss_full']:.4f} "
+                f"tens={val_metrics['loss_tens']:.4f} "
+                f"ones={val_metrics['loss_ones']:.4f} "
+                f"acc_full={val_metrics['acc_full']:.4f}"
+            )
+
+        if epoch % 5 == 0:
+            ckpt_path = checkpoint_dir / f"multitask_resnet34_epoch_{epoch:03d}.pth"
+            torch.save(model.state_dict(), ckpt_path)
+            print(f"Saved checkpoint: {ckpt_path}")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Description
This PR adds the multi-task jersey number recognition training stack end-to-end and aligns it with our proposal design.

## What I changed
* **Added a new shared-backbone multi-task recognizer in `recognition.py`:**
  * Single shared `ResNet34` backbone (not 3 separate models).
  * Removed backbone `fc` and replaced with `Identity`.
  * Added 3 parallel heads with exact output dims:
    * Full head: 100 classes (0..99)
    * Tens head: 11 classes (0..9 + blank(10))
    * Ones head: 10 classes (0..9)
  * `forward()` now returns `(out_full, out_tens, out_ones)` logits.
* **Added `train_multitask.py`:**
  * Imports the shared multi-task model.
  * Uses `CrossEntropyLoss` per head and sums losses: `total_loss = loss_full + loss_tens + loss_ones`
  * Backpropagates only `total_loss`.
  * Uses Adam with `lr=1e-4`.
  * Expects dataloader output as `(images, labels_full, labels_tens, labels_ones)`.
  * Adds `tqdm` progress bars and per-head loss logging.
  * Saves checkpoints every 5 epochs to `checkpoints/`.
* **Patched `jersey_number_dataset.py` (`JerseyNumberMultitaskDataset`) to enforce exact label semantics:**
  * 0..9 -> tens=10 (blank), ones=digit
  * 10..99 -> tens=label//10, ones=label%10
  * Added label range validation `[0,99]` to avoid silent bad labels.
  * Fixed transform selection to `data_transforms[mode][arch]` (callable transform path).

## Why this change
* Matches the proposal architecture (`ResNet34` + 3 heads).
* Fixes 1-digit vs 2-digit ambiguity through explicit tens/ones supervision.
* Reduces memory/compute overhead vs training 3 separate ResNet models.
* Removes activation misuse (`sigmoid`) before CE loss by returning raw logits.

## Validation I ran
* `py_compile` on new/modified files.
* Model forward shape smoke test: outputs `(B,100)`, `(B,11)`, `(B,10)`.
* 1-epoch synthetic mini-run of `train_multitask.py` (CPU) completed successfully.
* *Note:* I did **not** run the full pipeline training due to local compute limits.

## Notes for reviewers
* This PR covers architecture, training, and data-label correctness.
* Inference tie-break rule with confidence threshold `θ` should remain in inference logic (`main.py`/`helpers`) to match proposal wording.